### PR TITLE
Fix: Untitled Chat Edge Case

### DIFF
--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useAuth } from "@/contexts/UnifiedAuthProvider";
 import { useEncryption } from "@/hooks/useEncryption";
@@ -34,6 +34,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onClose }) => {
   const [loading, setLoading] = useState(true);
   const [isCreatingChat, setIsCreatingChat] = useState(false);
   const [isAttestationModalOpen, setIsAttestationModalOpen] = useState(false);
+  const staleChatsRef = useRef(false);
 
   // Utility function to truncate wallet address
   const truncateAddress = (address: string) => {
@@ -141,9 +142,16 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, onClose }) => {
           };
 
           processChats().then((realChats) => {
-            const realIds = new Set(realChats.map((c: ChatItem) => c._id));
+            const realIds = new Set<string>(
+              realChats.map((c: ChatItem) => c._id),
+            );
 
-            setChatHistory((prev) => {
+            if (!staleChatsRef.current) {
+              LocalStorageService.removeUntitledChatsNotIn(realIds);
+              staleChatsRef.current = true;
+            }
+
+            setChatHistory(() => {
               const localChats = LocalStorageService.getChatHistory();
               const optimistic = localChats.filter(
                 (c: ChatItem) =>

--- a/src/services/LocalStorage/index.ts
+++ b/src/services/LocalStorage/index.ts
@@ -37,4 +37,13 @@ export const LocalStorageService = {
     const filtered = current.filter((chat) => chat.title !== "Untitled Chat");
     LocalStorageService.setChatHistory(filtered);
   },
+
+  removeUntitledChatsNotIn: (idsToKeep: string[] | Set<string>): void => {
+    const keep = new Set(idsToKeep);
+    const current = LocalStorageService.getChatHistory();
+    const filtered = current.filter(
+      (chat) => chat.title !== "Untitled Chat" || keep.has(chat._id),
+    );
+    LocalStorageService.setChatHistory(filtered);
+  },
 };


### PR DESCRIPTION
Edge Case:
If user has pressed "Untitled Chat" too much before hand of recent fix, it will persist in LocalStorage


Previous: 
<img width="276" height="339" alt="image" src="https://github.com/user-attachments/assets/789907ac-b7fe-4464-a3a6-86d278ec7459" />

Expected: 
1. No new "untitled chats" should appear on load
2. If you press a lot of "New Chats", untitled chats will appear but will disappear after reloading page. 